### PR TITLE
Remove text about refundable shares

### DIFF
--- a/config/locales/members.yml
+++ b/config/locales/members.yml
@@ -280,8 +280,8 @@ _:
     members:
       new:
         acp_shares_text:
-          _de: Jedes Mitglied tritt dem Verein bei und muss je nach Taschengrösse ein oder mehere Anteilscheine (<b>%{price}</b>/Anteilschein) erwerben. Diese Anteilscheine werden bei einem Austritt vollständig zurückgezahlt.
-          _fr: Chaque membre fait également partie de l'association et se doit d'acquérir des parts sociales (<b>%{price}</b>/part) en fonction de la taille de son panier. Ces parts sociales sont intégralement remboursées si le membre décide de quitter l'association.
+          _de: Jedes Mitglied tritt der Genossenschaft bei und muss ein oder merhere Anteilscheine (<b>%{price}</b>/Anteilschein) erwerben.
+          _fr: Chaque membre fait également partie de la coopérative et se doit d'acquérir des parts sociales (<b>%{price}</b>/part).
         annual_fee_text:
           _de: Jedes Mitglied tritt dem Verein bei und zahlt zusätzlich zum Gemüseabo einen jährlichen Beitrag von <b>%{price}</b> ein.
           _fr: Chaque membre fait également partie de l'association et verse une cotisation anuelle de <b>%{price}</b> en plus de l'abonnement à son panier.


### PR DESCRIPTION
I have a few simplification proposal in the text about the share so that it can also fit with lamule choices.

1. At lamule.ch, we do not refund the first share (but we do refund the other ones). The text that is removed can easily be part of the custom section below.
2. We think that the use of share is for coopérative, so we change the name from association to coopérative on this text.
3. We do not have a different number of share to take for the different offer, so we would like also to remove the text related to that. Again, it can easily be specified in the custom text section just below.

Let me know :-)