### PR TITLE
Bump `.herb.yml` version to `0.10.3`

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -11,7 +11,7 @@
 # GitHub Repo: https://github.com/marcoroth/herb
 #
 
-version: 0.10.1
+version: 0.10.3
 
 files:
   # Patterns to exclude (can exclude defaults too)


### PR DESCRIPTION
Thanks for keeping up-to-date with the Herb releases and using it in your app!

I have been doing some research on the Herb usage over in [`herb-corpus`](https://github.com/marcoroth/herb-corpus) and saw that bumping the `version` in your `.herb.yml` passes both new rules introduced in `v0.10.3`. So I thought I'll open a PR to update it 😊 